### PR TITLE
add- slack summarizing skill to architect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ local.py
 /data/json/
 trial/*
 *.mp4
+frontend/

--- a/core/architect_bot.py
+++ b/core/architect_bot.py
@@ -23,6 +23,7 @@ from utils.opik_tracer import trace
 import plotly.io as pio
 import tempfile
 import os
+import json
 from rag.multimedia_rag.audio_transcriper import process_slack_audio_event
 from rag.multimedia_rag.video_rag import process_slack_video_event, process_video_with_rag
 logger = logging.getLogger(__name__)
@@ -37,7 +38,51 @@ class ArchitectBotHandler:
         )
         self.architect_service = ArchitectService()
         self._register_handlers()
-    
+
+    async def _get_thread_summary(self, client: WebClient, channel: str, thread_ts: str) -> (Optional[str], Optional[list]):
+        """Fetches and summarizes a Slack thread, returning the summary text and messages."""
+        all_messages = []
+        cursor = None
+        while True:
+            history = await client.conversations_replies(
+                channel=channel,
+                ts=thread_ts,
+                limit=200,
+                cursor=cursor
+            )
+            messages = history.get('messages', [])
+            all_messages.extend(messages)
+            
+            if not history.get('has_more'):
+                break
+            cursor = history.get('response_metadata', {}).get('next_cursor')
+
+        user_names_cache = {}
+        formatted_messages = []
+        for msg in all_messages:
+            msg_user_id = msg.get('user')
+            msg_text = msg.get('text', '').strip()
+            if not msg_user_id or not msg_text:
+                continue
+            
+            if msg_user_id not in user_names_cache:
+                user_names_cache[msg_user_id] = f"<@{msg_user_id}>"
+                # try:
+                #     user_info = await client.users_info(user=msg_user_id)
+                #     user_names_cache[msg_user_id] = user_info['user']['profile']['real_name_normalized']
+                # except SlackApiError:
+                #     user_names_cache[msg_user_id] = f"<@{msg_user_id}>"
+            
+            user_name = user_names_cache[msg_user_id]
+            formatted_messages.append(f"**{user_name}**: {msg_text}")
+
+        if not formatted_messages:
+            return "There doesn't seem to be any text content to summarize in this thread.", None
+        
+        thread_content = "\n".join(formatted_messages)
+        summary_text = await self.architect_service.summarize_thread(thread_content)
+        return summary_text, all_messages
+
     def _register_handlers(self):
         """Register all Architect-specific Slack event handlers"""
         
@@ -198,56 +243,69 @@ class ArchitectBotHandler:
 
             # Check for summarization keywords
             if any(keyword in query_text.lower() for keyword in ['summary', 'summarise', 'summarize']):
-                if 'thread_ts' not in event:
-                    await say("I can only summarize conversations in a thread. Please mention me in a reply to the thread you want summarized.", thread_ts=event['ts'])
-                    return
-
-                await say(f"Sure, I'll summarize this thread for you. One moment... 🧐", thread_ts=thread_ts)
-                try:
-                    # 1. Fetch thread history
-                    history = await client.conversations_replies(channel=channel, ts=thread_ts, limit=999)
-                    messages = history.get('messages', [])
+                url_match = re.search(r"<https?://[\w.-]+\.slack\.com/archives/(\w+)/p(\d+)>", query_text)
+                if url_match:
+                    # URL summarization
+                    summarize_channel_id = url_match.group(1)
+                    ts_string = url_match.group(2)
+                    summarize_thread_ts = f"{ts_string[:-6]}.{ts_string[-6:]}"
                     
-                    # 2. Format messages for the LLM, fetching user names
-                    user_names_cache = {}
-                    formatted_messages = []
-                    for msg in messages:
-                        msg_user_id = msg.get('user')
-                        msg_text = msg.get('text', '').strip()
-                        if not msg_user_id or not msg_text:
-                            continue
-                        
-                        # Fetch user name if not in cache
-                        if msg_user_id not in user_names_cache:
+                    await client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=f"Sure, I'll summarize the linked thread for you. One moment... 🧐")
+                    try:
+                        summary_text, messages = await self._get_thread_summary(client, summarize_channel_id, summarize_thread_ts)
+                        if messages:
                             try:
-                                user_info = await client.users_info(user=msg_user_id)
-                                user_names_cache[msg_user_id] = user_info['user']['profile']['real_name_normalized']
-                            except SlackApiError:
-                                user_names_cache[msg_user_id] = "Unknown User"
-                        
-                        user_name = user_names_cache[msg_user_id]
-                        formatted_messages.append(f"**{user_name}**: {msg_text}")
-
-                    if not formatted_messages:
-                        await say("There doesn't seem to be any text content to summarize in this thread.", thread_ts=thread_ts)
+                                messages_json = json.dumps(messages, indent=2)
+                                with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix=".json") as temp_file:
+                                    temp_file.write(messages_json)
+                                    temp_file_path = temp_file.name
+                                
+                                await client.files_upload_v2(
+                                    channel=channel,
+                                    thread_ts=thread_ts,
+                                    file=temp_file_path,
+                                    title="Thread Messages (JSON)",
+                                    initial_comment="Here are the raw messages from the thread for debugging."
+                                )
+                                os.remove(temp_file_path)
+                            except Exception as json_e:
+                                logger.error(f"Failed to serialize and upload messages as JSON: {json_e}")
+                        if summary_text:
+                            await client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=summary_text)
+                    except Exception as e:
+                        logger.error(f"URL Thread summarization failed: {e}", exc_info=True)
+                        await client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=f"❌ I ran into an issue trying to summarize the linked thread: {str(e)}")
+                else:
+                    # Current thread summarization
+                    if 'thread_ts' not in event:
+                        await say("I can only summarize conversations in a thread. Please mention me in a reply to the thread you want summarized.")
                         return
                     
-                    thread_content = "\n".join(formatted_messages)
-
-                    # 3. Call the architect service to summarize
-                    summary_text = await self.architect_service.summarize_thread(thread_content)
-
-                    # 4. Post the summary
-                    await say(text=summary_text, thread_ts=thread_ts)
-                    trace("slack.thread_summary_complete", {"user_id": user_id, "channel": channel})
-
-                except SlackApiError as e:
-                    logger.error(f"Slack API error during summarization: {e}")
-                    await say(f"❌ I couldn't fetch the thread history. Error: {e.response['error']}", thread_ts=thread_ts)
-                except Exception as e:
-                    logger.error(f"Thread summarization failed: {e}", exc_info=True)
-                    trace("slack.thread_summary_error", {"error": str(e)})
-                    await say(f"❌ I ran into an issue trying to summarize the thread: {str(e)}", thread_ts=thread_ts)
+                    await say(f"Sure, I'll summarize this thread for you. One moment... 🧐")
+                    try:
+                        summary_text, messages = await self._get_thread_summary(client, channel, thread_ts)
+                        if summary_text:
+                            await say(summary_text)
+                        if messages:
+                            try:
+                                messages_json = json.dumps(messages, indent=2)
+                                with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix=".json") as temp_file:
+                                    temp_file.write(messages_json)
+                                    temp_file_path = temp_file.name
+                                
+                                await client.files_upload_v2(
+                                    channel=channel,
+                                    thread_ts=thread_ts,
+                                    file=temp_file_path,
+                                    title="Thread Messages (JSON)",
+                                    initial_comment="Here are the raw messages from the thread for debugging."
+                                )
+                                os.remove(temp_file_path)
+                            except Exception as json_e:
+                                logger.error(f"Failed to serialize and upload messages as JSON: {json_e}")
+                    except Exception as e:
+                        logger.error(f"Thread summarization failed: {e}", exc_info=True)
+                        await say(f"❌ I ran into an issue trying to summarize the thread: {str(e)}")
                 return
 
             # --- Fallback to original research logic ---
@@ -271,11 +329,9 @@ class ArchitectBotHandler:
                 await say(f"❌ Research failed: {str(e)}", thread_ts=thread_ts)
 
         @self.app.event("message")
-        async def handle_message_events(body, logger,say):
-            logger.info(body)
+        async def handle_message_events(body, logger, say, client: WebClient):
             event = body.get('event', {})
             files = event.get('files', [])
-            
             if event.get('subtype') == 'file_share' and files:
                 for f in files:
                     mimetype = f.get('mimetype', '')

--- a/services/architect/agent.py
+++ b/services/architect/agent.py
@@ -150,7 +150,7 @@ Always provide thorough, evidence-based analysis that helps users make informed 
             A markdown-formatted string containing the summary.
         """
         logger.info("Starting thread summarization with summarizer_agent.")
-        
+        print(thread_content)
         # This prompt is specifically designed for the thread summarization task
         prompt = f"""
 You are an expert assistant that summarizes Slack conversations.
@@ -160,6 +160,7 @@ Your task is to create a summary with two distinct sections:
 1.  **General Summary**: A concise paragraph covering the main topics, key questions, and any decisions or action items that came out of the discussion.
 2.  **Key Points per Participant**: A section that lists each person who spoke. Under each name, provide a bulleted list of their primary contributions, questions, and conclusions.
 
+!!! Important: Make sure to summarise points for all the participants in the thread, not just the last few.
 Please format the entire output using Slack's markdown for readability.
 
 **Thread Content to Summarize:**

--- a/services/architect/agent.py
+++ b/services/architect/agent.py
@@ -138,6 +138,47 @@ Always provide thorough, evidence-based analysis that helps users make informed 
             trace("architect.research_error", {"error": str(e)})
             raise
 
+    async def summarize_thread(self, thread_content: str) -> str:
+        """
+        Summarizes a given string of Slack thread content using the summarizer_agent.
+
+        Args:
+            thread_content: A formatted string containing the thread's messages,
+                            including participant names.
+
+        Returns:
+            A markdown-formatted string containing the summary.
+        """
+        logger.info("Starting thread summarization with summarizer_agent.")
+        
+        # This prompt is specifically designed for the thread summarization task
+        prompt = f"""
+You are an expert assistant that summarizes Slack conversations.
+The following text is a transcript of a Slack thread, with each message prefixed by the participant's name.
+
+Your task is to create a summary with two distinct sections:
+1.  **General Summary**: A concise paragraph covering the main topics, key questions, and any decisions or action items that came out of the discussion.
+2.  **Key Points per Participant**: A section that lists each person who spoke. Under each name, provide a bulleted list of their primary contributions, questions, and conclusions.
+
+Please format the entire output using Slack's markdown for readability.
+
+**Thread Content to Summarize:**
+---
+{thread_content}
+---
+"""
+        
+        try:
+            # Use the existing summarizer agent to run the task
+            response = await self.summarizer_agent.run(prompt)
+            summary = response.data
+            trace("architect.thread_summary_complete", {"summary_length": len(summary)})
+            return summary
+        except Exception as e:
+            logger.error(f"Failed to generate thread summary using agent: {e}", exc_info=True)
+            trace("architect.thread_summary_error", {"error": str(e)})
+            return f"❌ I'm sorry, I encountered an error while trying to generate the summary: {e}"
+    # --- END OF ADDED METHOD --->
     async def _create_research_plan(self, request: ArchitectRequest, research_id: str) -> ResearchPlan:
         """Create a detailed research plan"""
         

--- a/services/architect/service.py
+++ b/services/architect/service.py
@@ -93,6 +93,41 @@ class ArchitectService:
             trace("architect_service.research_error", {"error": str(e)})
             raise
 
+    async def summarize_thread(self, thread_content: str) -> str:
+        """
+        Summarizes a given string of thread content using an LLM.
+
+        Args:
+            thread_content: A formatted string containing the entire thread's messages.
+
+        Returns:
+            A markdown-formatted string containing the summary.
+        """
+        # This is a high-level system prompt that works well for this task.
+        # It instructs the LLM on the desired output format.
+        system_prompt = """
+        You are a helpful assistant specialized in summarizing Slack conversations.
+        Your task is to provide a clear and concise summary of the provided thread.
+        Please structure your output as follows:
+
+        1.  **General Summary**: A brief, high-level overview of the entire discussion, including the main topics, questions, and any conclusions or action items.
+        2.  **Key Points per Participant**: Under this heading, list each participant who contributed to the thread. For each person, create a bulleted list of their most important points, questions asked, and decisions made.
+
+        Format your entire response in Slack's markdown.
+    """
+    
+        # This is a conceptual example. Replace with your actual LLM client call.
+        # Here you would call your LLM service (e.g., OpenAI, Anthropic, Gemini)
+        # This is a conceptual example. Replace with your actual LLM client call.
+        try:
+            summary = await self.agent.summarize_thread(thread_content=thread_content)
+            return summary
+
+        except Exception as e:
+            logger.error(f"LLM summarization call failed: {e}")
+            return f"I'm sorry, but I was unable to generate a summary due to an internal error: {e}"
+
+
     async def get_research_status(self, research_id: str) -> Optional[Dict[str, Any]]:
         """Get the status of a research request"""
         if research_id in self.active_research:

--- a/slack_setup/mainfests/architect.json
+++ b/slack_setup/mainfests/architect.json
@@ -26,7 +26,8 @@
                 "channels:history",
                 "groups:history",
                 "chat:write",
-                "files:write"
+                "files:write",
+                "app_mentions:read"
             ]
         }
     },
@@ -35,7 +36,8 @@
             "bot_events": [
                 "assistant_thread_context_changed",
                 "assistant_thread_started",
-                "message.im"
+                "message.im",
+                "app_mention"
             ]
         },
         "interactivity": {

--- a/slack_setup/mainfests/data-analyst.json
+++ b/slack_setup/mainfests/data-analyst.json
@@ -26,7 +26,8 @@
                 "channels:history",
                 "groups:history",
                 "chat:write",
-                "files:write"
+                "files:write",
+                "app_mentions:read"
             ]
         }
     },
@@ -35,7 +36,8 @@
             "bot_events": [
                 "assistant_thread_context_changed",
                 "assistant_thread_started",
-                "message.im"
+                "message.im",
+                "app_mention"
             ]
         },
         "interactivity": {

--- a/slack_setup/mainfests/developer.json
+++ b/slack_setup/mainfests/developer.json
@@ -26,7 +26,8 @@
                 "channels:history",
                 "groups:history",
                 "chat:write",
-                "files:write"
+                "files:write",
+                "app_mentions:read"
             ]
         }
     },
@@ -35,7 +36,8 @@
             "bot_events": [
                 "assistant_thread_context_changed",
                 "assistant_thread_started",
-                "message.im"
+                "message.im",
+                "app_mention"
             ]
         },
         "interactivity": {

--- a/slack_setup/mainfests/manager.json
+++ b/slack_setup/mainfests/manager.json
@@ -26,7 +26,8 @@
                 "channels:history",
                 "groups:history",
                 "chat:write",
-                "files:write"
+                "files:write",
+                "app_mentions:read"
             ]
         }
     },
@@ -35,7 +36,8 @@
             "bot_events": [
                 "assistant_thread_context_changed",
                 "assistant_thread_started",
-                "message.im"
+                "message.im",
+                "app_mention"
             ]
         },
         "interactivity": {

--- a/slack_setup/mainfests/prod-support.json
+++ b/slack_setup/mainfests/prod-support.json
@@ -26,7 +26,8 @@
                 "channels:history",
                 "groups:history",
                 "chat:write",
-                "files:write"
+                "files:write",
+                "app_mentions:read"
             ]
         }
     },
@@ -35,7 +36,8 @@
             "bot_events": [
                 "assistant_thread_context_changed",
                 "assistant_thread_started",
-                "message.im"
+                "message.im",
+                "app_mention"
             ]
         },
         "interactivity": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for users to mention the bot in Slack and request a summary of a thread using keywords like "summary" or "summarize". The bot generates and posts a structured summary of the discussion, including key points by participant.
  * Enhanced the bot to support summarizing linked Slack threads via URLs or the current thread when mentioned.
  * Added uploading of raw thread messages as JSON files for debugging within Slack threads.
* **Chores**
  * Updated the `.gitignore` file to exclude the `frontend/` directory.
  * Expanded Slack app permissions and event subscriptions to include app mention events across multiple bot configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->